### PR TITLE
feat: add 'respect eof' option for reading from bounded sources

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,13 +200,13 @@ where
                     }
                     // if there was an error, log it but move on because this could be a partial entry
                     Some(Err(err)) => {
-                        if self.respect_eof
+                        if *this.respect_eof
                             && err.is_eof()
                             && this.entry_buffer.is_empty()
                             && buffer.is_empty()
                         {
                             self.finish();
-                            return Poll::Ready(Some(Err(err)));
+                            return Poll::Ready(None);
                         } else {
                             trace!(err = ?err, "failed to parse json entry");
                             break;


### PR DESCRIPTION
Sorry for not opening a pull request with this, I ended up running
into the obvious problem when reading from finite sources.

I'm happy to write tests for this though I wanted to see if you had
opinions on how to mock this out or handle it. (Or even if you were interested,)